### PR TITLE
fix: Avoid bills or payment proof if no href element found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -399,21 +399,22 @@ class CdiscountContentScript extends ContentScript {
       const orderCardRight = ordersElement.querySelector(
         '.czOrderHeaderBlocRight'
       )
-      const orderBillHref = orderCardRight.querySelector(
+      const orderBillHrefElement = orderCardRight.querySelector(
         'a[title="Imprimer la facture"]'
       )
-        ? (() => {
-            documentType = 'bill'
-            return orderCardRight
-              .querySelector('a[title="Imprimer la facture"]')
-              .getAttribute('href')
-          })()
-        : (() => {
-            documentType = 'proof'
-            return orderCardRight
-              .querySelector('a[title="Imprimer la preuve d\'achat"]')
-              .getAttribute('href')
-          })()
+      let orderBillHref
+
+      if (orderBillHrefElement) {
+        documentType = 'bill'
+        orderBillHref = orderCardRight
+          .querySelector('a[title="Imprimer la facture"]')
+          ?.getAttribute('href')
+      } else {
+        documentType = 'proof'
+        orderBillHref = orderCardRight
+          .querySelector('a[title="Imprimer la preuve d\'achat"]')
+          ?.getAttribute('href')
+      }
       if (!orderBillHref) {
         this.log('info', 'No bills to download, jumping this order')
         j++


### PR DESCRIPTION
This PR aims to fix a user problem encountered when there is either no bills or paymentProof to download.
Until now, every tested account had at least one of the two. It seems it's not true for every account so this should fix the issue.

Now if you cannot find at least one of them, we're continue the loop, avoiding the problematic order.